### PR TITLE
Update config.coffee

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -17,7 +17,7 @@ module.exports =
   enabledFiletypes:
     type: 'array'
     items: type: 'string'
-    default: ['c, cpp, objc, objcpp']
+    default: ['c', 'cpp', 'objc', 'objcpp']
     order: 3
     description: '
       An array of filetypes within we should provide completions and diagnostics.


### PR DESCRIPTION
there is a typo after changing enabledFiletypes to array type --- each file type need to be quoted separately. Issue #51 fixed after this patch.