### PR TITLE
Add provider for hyperclick package

### DIFF
--- a/lib/menu.coffee
+++ b/lib/menu.coffee
@@ -42,3 +42,4 @@ deregister = ->
 module.exports =
   register: register
   deregister: deregister
+  runCommand: runCommand

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,6 +1,7 @@
 utility = require './utility'
 getCompletions = require './get-completions'
 getIssues = require './get-issues'
+menu = require './menu'
 
 module.exports =
   selector: '*'
@@ -20,3 +21,9 @@ module.exports =
     return [] unless utility.isEnabledForScope editor.getRootScopeDescriptor()
     return [] unless atom.config.get 'you-complete-me.linterEnabled'
     getIssues(editor).catch utility.notifyError []
+
+  getSuggestionForWord: (editor, text, range) ->
+    if utility.isEnabledForScope editor.getRootScopeDescriptor()
+      callback = ->
+        menu.runCommand 'GoToImprecise'
+      return {range, callback}

--- a/lib/ycm.coffee
+++ b/lib/ycm.coffee
@@ -19,3 +19,4 @@ module.exports =
   deactivate: deactivate
   provide: -> provider
   provideLinter: -> provider
+  provideHyperclick: -> provider

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
       "versions": {
         "1.0.0": "provideLinter"
       }
+    },
+    "hyperclick.provider": {
+      "versions": {
+        "0.0.0": "provideHyperclick"
+      }
     }
   }
 }


### PR DESCRIPTION
Allows the user to click on a word to run the `GoToImprecise` command.
More info: [hyperclick](https://github.com/facebooknuclideapm/hyperclick)