### PR TITLE
ycmd launch race condition fix, update events to behave more like YCM vim plugin, fix file_data to only include files that are enabled for scope

### DIFF
--- a/lib/utility.coffee
+++ b/lib/utility.coffee
@@ -34,7 +34,7 @@ buildRequestParameters = (filepath, contents, filetypes = [], bufferPosition = n
     file_data: {}
   parameters.file_data[filepath] = {contents, filetypes: filetypes.map(filetypeMapper)}
   atom.workspace.getTextEditors()
-    .filter (editor) -> editor.isModified() and editor.getPath()? and editor.getPath() isnt filepath
+    .filter (editor) -> editor.isModified() and editor.getPath()? and editor.getPath() isnt filepath and isEnabledForScope editor.getRootScopeDescriptor()
     .forEach (editor) -> parameters.file_data[editor.getPath()] =
       contents: editor.getText()
       filetypes: getScopeFiletypes(editor.getRootScopeDescriptor()).map(filetypeMapper)


### PR DESCRIPTION
The YCM vim plug calls FileReadyToParse when changes stop. In large projects with large C++ files where libclang can take > 2 seconds to parse, this prevents constant "YCMD errors of still parsing file" 

http://puremourning.github.io/ycmd-1/

