### PR TITLE
Add tags completion support

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -22,6 +22,7 @@ module.exports =
     description: '
       An array of filetypes within we should provide completions and diagnostics.
       They are equivalent to file extensions most of the time.
+      Use * if you want to enable all filetypes.
     '
   linterEnabled:
     type: 'boolean'

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -22,7 +22,6 @@ module.exports =
     description: '
       An array of filetypes within we should provide completions and diagnostics.
       They are equivalent to file extensions most of the time.
-      Use * if you want to enable all filetypes.
     '
   linterEnabled:
     type: 'boolean'

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -14,11 +14,19 @@ module.exports =
       The directory containing the `ycmd/default_settings.json` file.
       [Ycmd](https://github.com/Valloric/ycmd) is required for this plugin to work.
     '
+  ycmdSettingPath:
+    type: 'string'
+    default: 'ycmd/default_settings.json'
+    order: 3
+    description: '
+      The `default_settings.json` to start ycmd server.
+      Copy the `ycmd/default_settings.json` file and modify as needed.
+    '
   enabledFiletypes:
     type: 'array'
     items: type: 'string'
     default: ['c', 'cpp', 'objc', 'objcpp']
-    order: 3
+    order: 4
     description: '
       An array of filetypes within we should provide completions and diagnostics.
       They are equivalent to file extensions most of the time.
@@ -26,14 +34,14 @@ module.exports =
   linterEnabled:
     type: 'boolean'
     default: true
-    order: 4
+    order: 5
     description: '
       Disable linter if you do not need those diagnostic messages.
     '
   globalExtraConfig:
     type: 'string'
     default: ''
-    order: 5
+    order: 6
     description: '
       The fallback extra config file when no `.ycm_extra_conf.py` is found.
       Follow [this link](https://github.com/Valloric/YouCompleteMe#the-gycm_global_ycm_extra_conf-option) for more information.
@@ -41,7 +49,7 @@ module.exports =
   confirmExtraConfig:
     type: 'boolean'
     default: true
-    order: 6
+    order: 7
     description: '
       Whether to ask once before loading an extra config file for safety reason.
       To selectively whitelist or blacklist them, use **Extra Config Globlist** option.
@@ -51,7 +59,7 @@ module.exports =
     type: 'array'
     items: type: 'string'
     default: []
-    order: 7
+    order: 8
     description: '
       Extra config files whitelist and blacklist,
       e.g. `~/dev/*, !~/*` would make it load all `.ycm_extra_conf.py` under `~/dev/` and not to load all other `.ycm_extra_conf.py` under `~/`, without confirmation.
@@ -60,7 +68,7 @@ module.exports =
   rustSrcPath:
     type: 'string'
     default: ''
-    order: 8
+    order: 9
     description: '
       The directory containing the [Rust source code](https://github.com/rust-lang/rust).
       You have also to to add `rust` in **Enabled Filetypes**.

--- a/lib/get-completions.coffee
+++ b/lib/get-completions.coffee
@@ -27,11 +27,12 @@ convertCompletions = ({completions, prefix, filetypes}) ->
         text: completion.insertion_text
         replacementPrefix: prefix
         displayText: completion.menu_text
-        leftLabel: completion.extra_menu_info
+        leftLabel: completion.extra_menu_info.replace(/(^\[|\]$)/g, '')
         rightLabel: completion.kind
         description: completion.detailed_info
-      suggestion.type = switch completion.kind
+      suggestion.type = switch completion.extra_menu_info
         when '[File]', '[Dir]', '[File&Dir]' then 'import'
+        when '[ID]' then 'keyword'
         else null
       return suggestion
 

--- a/lib/handler.coffee
+++ b/lib/handler.coffee
@@ -33,8 +33,11 @@ launch = (exit) ->
         reject error
 
   readDefaultOptions = new Promise (fulfill, reject) ->
-    defaultOptionsFile = path.resolve atom.config.get('you-complete-me.ycmdPath'), 'ycmd', 'default_settings.json'
-    fs.readFile defaultOptionsFile, encoding: 'utf8', (error, data) ->
+    customOptionsFile = path.resolve atom.config.get('you-complete-me.ycmdSettingPath')
+    fs.exists customOptionsFile, (exists) ->
+      unless exists?
+        customOptionsFile = path.resolve atom.config.get('you-complete-me.ycmdPath'), 'ycmd', 'default_settings.json'
+    fs.readFile customOptionsFile, encoding: 'utf8', (error, data) ->
       unless error?
         fulfill JSON.parse data
       else

--- a/lib/utility.coffee
+++ b/lib/utility.coffee
@@ -60,8 +60,6 @@ buildRequestParameters = (filepath, contents, filetypes = [], bufferPosition = n
 
 isEnabledForScope = (scopeDescriptor) ->
   enabledFiletypes = atom.config.get 'you-complete-me.enabledFiletypes'
-  if enabledFiletypes.indexOf('*')
-    return true
   filetypes = getScopeFiletypes scopeDescriptor
   filetype = filetypes.find (filetype) -> enabledFiletypes.indexOf(filetype) >= 0
   return if filetype? then true else false

--- a/lib/utility.coffee
+++ b/lib/utility.coffee
@@ -44,6 +44,7 @@ buildRequestParameters = (filepath, contents, filetypes = [], bufferPosition = n
     line_num: bufferPosition.row + 1
     column_num: bufferPosition.column + 1
     file_data: {}
+    tag_files: ['.tags', 'tags'].map (t) -> path.join(workingDir, t)
   parameters.file_data[filepath] = {contents, filetypes: convertFiletypes filetypes}
   atom.workspace.getTextEditors()
     .filter (editor) ->

--- a/lib/utility.coffee
+++ b/lib/utility.coffee
@@ -58,6 +58,8 @@ buildRequestParameters = (filepath, contents, filetypes = [], bufferPosition = n
 
 isEnabledForScope = (scopeDescriptor) ->
   enabledFiletypes = atom.config.get 'you-complete-me.enabledFiletypes'
+  if enabledFiletypes.indexOf('*')
+    return true
   filetypes = getScopeFiletypes scopeDescriptor
   filetype = filetypes.find (filetype) -> enabledFiletypes.indexOf(filetype) >= 0
   return if filetype? then true else false

--- a/lib/utility.coffee
+++ b/lib/utility.coffee
@@ -35,6 +35,7 @@ buildRequestParameters = (filepath, contents, filetypes = [], bufferPosition = n
   convertFiletypes = (filetypes) ->
     filetypes.map((filetype) -> switch filetype
       when 'js', 'jsx' then 'javascript'
+      when 'ahk' then 'autohotkey'
       else filetype
     ).filter (filetype, index, filetypes) -> filetypes.indexOf(filetype) is index
   workingDir = getWorkingDirectory()


### PR DESCRIPTION
> Refer to #71

To support custom filetype like autohotkey, the LANG_TO_FILETYPE map inside `ycmd\cpp\ycm\IdentifierUtils.cpp`
needs to be patched.

```cpp
// List of languages Exuberant Ctags supports:
//   ctags --list-languages
// To map a language name to a filetype, see this file:
//   :e $VIMRUNTIME/filetype.vim
// This is a map of const char* and not std::string to prevent issues with
// static initialization.
const boost::unordered_map < const char *,
      const char *,
      boost::hash< std::string >,
      StringEqualityComparer > LANG_TO_FILETYPE =
        boost::assign::map_list_of
        ( "Ant"        , "ant"        )
        ( "Asm"        , "asm"        )
        ( "Awk"        , "awk"        )
        ( "autohotkey" , "autohotkey" )
```