### PR TITLE
Changes required for upcoming CoffeeScript upgrade

### DIFF
--- a/lib/get-issues.coffee
+++ b/lib/get-issues.coffee
@@ -11,7 +11,7 @@ fetchIssues = ({filepath, contents, filetypes}) ->
   parameters.event_name = 'FileReadyToParse'
   handler.request('POST', 'event_notification', parameters).then (response) ->
     Promise.resolve if Array.isArray response then response else []
-      .then (issues) -> Promise.all issues.map (issue) ->
+      .then (issues) -> (Promise.all issues.map (issue) ->
         if issue.fixit_available
           command.run('FixIt', [issue.location.line_num - 1, issue.location.column_num - 1]).then (response) ->
             issue.fixits = if Array.isArray response?.fixits then response.fixits else []
@@ -19,7 +19,7 @@ fetchIssues = ({filepath, contents, filetypes}) ->
         else
           issue.fixits = []
           Promise.resolve issue
-      .then (issues) -> {issues, filetypes}
+      ).then (issues) -> {issues, filetypes}
 
 convertIssues = ({issues, filetypes}) ->
   converter = (filetype) ->


### PR DESCRIPTION
Hello!

In Atom 1.23.0, the CoffeeScript dependency [will be upgraded from version 1.11.1 to 1.12.7](https://github.com/atom/atom/pull/13731). To ensure that all packages will remain working the same way, we searched for CoffeeScript compile output differences from all Atom packages and found your package to be affected by the update.

This pull request implements the fix mentioned in https://github.com/jashkenas/coffeescript/issues/4760#issuecomment-340001235, which is compatible with both versions.

It could be that the code will remain working despite the compiled output takes slightly different approach. If you believe this is the case, feel free to just close this pull request and consider this just as a heads-up.

Please let me know if you have any questions.